### PR TITLE
Add Cloud Foundry manifest and production server config

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,17 @@ docker run -p 5001:5001 dummy-mission-system
 
 The server will run on `http://localhost:5001`
 
+### cloud.gov / Cloud Foundry
+
+Deploy the application to [cloud.gov](https://cloud.gov/) (Cloud Foundry) using the provided `manifest.yml`:
+
+```bash
+# Authenticate with cloud.gov first, then target the appropriate org/space.
+cf push
+```
+
+The manifest configures the Python buildpack, installs dependencies from `requirements.txt`, and starts the app with Gunicorn bound to the platform-provided `$PORT`.
+
 ## API Endpoints
 
 ### GET /

--- a/app.py
+++ b/app.py
@@ -1,3 +1,5 @@
+import os
+
 from flask import Flask, jsonify, request
 
 app = Flask(__name__)
@@ -557,4 +559,6 @@ def internal_error(error):
 
 
 if __name__ == '__main__':
-    app.run(debug=True, host='0.0.0.0', port=5001)
+    debug_mode = os.environ.get("FLASK_DEBUG", "0") == "1"
+    port = int(os.environ.get("PORT", 5001))
+    app.run(debug=debug_mode, host='0.0.0.0', port=port)

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,13 @@
+---
+applications:
+  - name: dummy-mission-system
+    memory: 256M
+    disk_quota: 512M
+    instances: 1
+    timeout: 120
+    buildpacks:
+      - python_buildpack
+    command: gunicorn app:app --bind 0.0.0.0:$PORT
+    env:
+      FLASK_ENV: production
+    random-route: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 Flask==3.0.0
+gunicorn==21.2.0


### PR DESCRIPTION
## Summary
- add a Cloud Foundry manifest that uses the Python buildpack and runs the app with Gunicorn
- update the Flask entrypoint to honor platform-provided PORT/FLASK_DEBUG settings
- document cloud.gov deployment and include Gunicorn in the dependencies

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68e000932614832ca1f3d26b8b39cda4